### PR TITLE
fix: types to support canvas or image ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import React from 'react';
 import { useQRCode } from 'react-qrcodes';
 
 function App() {
-  const [inputRef] = useQRCode({
+  const [inputRef] = useQRCode<HTMLCanvasElement>({
     text: 'https://github.com/bunlong/react-qrcodes',
     options: {
       level: 'M',
@@ -150,7 +150,7 @@ import React from 'react';
 import { useQRCode } from 'react-qrcodes';
 
 function App() {
-  const [inputRef] = useQRCode({
+  const [inputRef] = useQRCode<HTMLImageElement>({
     text: 'https://github.com/bunlong/react-qrcodes',
     options: {
       type: 'image/jpeg',

--- a/src/useQRCode.ts
+++ b/src/useQRCode.ts
@@ -21,10 +21,10 @@ export interface ReactQRCodeColors {
   light?: string;
 }
 
-export function useQRCode({
+export function useQRCode<T extends HTMLCanvasElement | HTMLImageElement>({
   ...props
-}: ReactQRCodeProps): React.RefObject<HTMLCanvasElement | HTMLImageElement>[] {
-  const inputRef = useRef<HTMLCanvasElement | HTMLImageElement>(null);
+}: ReactQRCodeProps): React.RefObject<T>[] {
+  const inputRef = useRef<T>(null);
   const { text, options } = props;
 
   useEffect(

--- a/src/useQRCode.ts
+++ b/src/useQRCode.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 const QRCode = require('qrcode');
 
 export interface ReactQRCodeProps {
@@ -23,31 +23,37 @@ export interface ReactQRCodeColors {
 
 export function useQRCode({
   ...props
-}: ReactQRCodeProps): React.MutableRefObject<undefined>[] {
-  const inputRef = useRef();
+}: ReactQRCodeProps): React.RefObject<HTMLCanvasElement | HTMLImageElement>[] {
+  const inputRef = useRef<HTMLCanvasElement | HTMLImageElement>(null);
   const { text, options } = props;
 
   useEffect(
     function () {
-      if (inputRef) {
-        const ref = inputRef as any;
-        if (ref.current.tagName === 'CANVAS') {
-          QRCode.toCanvas(ref.current, text, options, function (error: any) {
-            if (error) {
-              throw error;
-            }
-          });
-        } else {
+      if (inputRef.current) {
+        if (inputRef.current instanceof HTMLCanvasElement) {
+          QRCode.toCanvas(
+            inputRef.current,
+            text,
+            options,
+            function (error: any) {
+              if (error) {
+                throw error;
+              }
+            },
+          );
+        } else if (inputRef.current instanceof HTMLImageElement) {
           QRCode.toDataURL(text, options, function (error: any, url: any) {
             if (error) {
               throw error;
             }
-            ref.current.src = url;
+            if (inputRef.current instanceof HTMLImageElement) {
+              inputRef.current.src = url;
+            }
           });
         }
       }
     },
-    [text, options],
+    [text, options, inputRef.current],
   );
 
   return [inputRef];


### PR DESCRIPTION
Previously the types could not be consumed properly in our application. The return type wanted to be the same as the return type of `useRef` and accept the generics of either `HTMLCanvasElement` or `HTMLImageElement`.

This PR makes that fix so that the proper return type is given, making the TypeScript compiler happy. 🍍 